### PR TITLE
Fix imports and add init for norm_computer

### DIFF
--- a/norm_computer/__init__.py
+++ b/norm_computer/__init__.py
@@ -1,0 +1,1 @@
+"""norm_computer package"""

--- a/norm_computer/compute_norm_grid.py
+++ b/norm_computer/compute_norm_grid.py
@@ -6,8 +6,8 @@ from multiprocessing import Pool, cpu_count
 from tqdm import tqdm
 from scipy.stats import norm
 from scipy.special import erf
-from lens_model import LensModel
-from lens_solver import solve_single_lens
+from ..lens_model import LensModel
+from ..lens_solver import solve_single_lens
 
 # === Utils ===
 # to check. use it to model the relation between logM_sps and logRe


### PR DESCRIPTION
## Summary
- add `__init__.py` to `norm_computer` so it can be used as a package
- use relative imports inside `norm_computer/compute_norm_grid.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b696ff744832d915e435803cbabda