### PR TITLE
Use cumulative trapezoid for kappaR integral

### DIFF
--- a/lens_model.py
+++ b/lens_model.py
@@ -4,7 +4,7 @@ from .sl_cosmology import Dang, G, M_Sun, Mpc, c, rhoc, yr
 from .sl_profiles import deVaucouleurs as deV, nfw
 from scipy.interpolate import interp1d, splev, splint, splrep
 from scipy.optimize import brentq, leastsq, minimize_scalar
-from scipy.integrate import quad
+from scipy.integrate import quad, cumulative_trapezoid
 
 
 @njit
@@ -91,7 +91,8 @@ class LensModel:
         self.kappaR_spline = splrep(self.Rkpc, kappa_array * self.Rkpc)  # for gamma
 
         self.kappaR_vals = splev(self.Rkpc, self.kappaR_spline)
-        self.kappaR_int = np.array([splint(0., R, self.kappaR_spline) for R in self.Rkpc])
+        # 使用累积梯形积分代替逐点 spline 积分，计算 ∫ kappa(R)·R dR
+        self.kappaR_int = cumulative_trapezoid(self.kappaR_vals, self.Rkpc, initial=0.0)
 
         kappa_star = self.kappa_star(self.Rkpc)
         m2d_star = self.M_star * deV.fast_M2d(self.Rkpc / self.Re)


### PR DESCRIPTION
## Summary
- Replace per-point spline integration with efficient `cumulative_trapezoid`

## Testing
- `pytest -q`
- Compared `splint` vs `cumulative_trapezoid` integrals (max relative diff ~1.4e-5)


------
https://chatgpt.com/codex/tasks/task_e_688f7535296c832d888e3078e40f47e9