### PR TITLE
Add precomputed table loading and integrate with MCMC

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,6 +25,7 @@ from .likelihood import (
     likelihood_single_fast_optimized,
     log_likelihood,
     log_posterior,
+    load_precomputed_tables,
 )
 from .utils import selection_function, mag_likelihood
 
@@ -49,6 +50,7 @@ __all__ = [
     "likelihood_single_fast_optimized",
     "log_likelihood",
     "log_posterior",
+    "load_precomputed_tables",
     "selection_function",
     "mag_likelihood",
 ]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 from .run_mcmc import run_mcmc
 from .likelihood import log_posterior
-from .interpolator import build_interp_list_for_lenses
 from .mock_generator import run_mock_simulation
 from .likelihood import log_posterior, initializer_for_pool
 import multiprocessing as mp
@@ -11,19 +10,9 @@ def main():
     mock_lens_data, mock_observed_data = run_mock_simulation(n_samples=100)
     mock_lens_data.to_csv(os.path.join(os.path.dirname(__file__), "tables", "mock_lens_data.csv"), index=True)
     mock_observed_data.to_csv(os.path.join(os.path.dirname(__file__), "tables", "mock_observed_data.csv"), index=True)
-    logMh_grid = np.linspace(11.5, 14.0, 100)
-
-    logMstar_list, detJ_list = build_interp_list_for_lenses(
-        mock_observed_data, logMh_grid, zl=0.3, zs=2.0
-    )
-
-    
-
     sampler = run_mcmc(
         data_df=mock_observed_data,
-        logMstar_interp_list=logMstar_list,
-        detJ_interp_list=detJ_list,
-        use_interp=True,
+        sim_id="sim_example",
         log_posterior_func=log_posterior,
         backend_file="mcmc_chain1000.h5",
         nwalkers=18,

--- a/test.py
+++ b/test.py
@@ -1,7 +1,6 @@
 """Not a Simple test module."""
 from .run_mcmc import run_mcmc
 from .likelihood import log_posterior
-from .interpolator import build_interp_list_for_lenses
 from .mock_generator import run_mock_simulation
 import numpy as np
 from .utils import fit_alphasps
@@ -13,20 +12,13 @@ import seaborn as sns
 
 def run():
     mock_lens_data, mock_observed_data = run_mock_simulation(n_samples=20)
-    logMh_grid = np.linspace(11.5, 14, 100)
-
-    logMstar_list, detJ_list = build_interp_list_for_lenses(
-        mock_observed_data, logMh_grid, zl=0.3, zs=2.0
-    )
     test_filename = "chains_eta4.h5"
     if os.path.exists(os.path.join(os.path.dirname(__file__),'chains', test_filename)):
         print(f"[INFO] 继续采样：读取已有文件 {test_filename}")
     
     sampler = run_mcmc(
         data_df=mock_observed_data,
-        logMstar_interp_list=logMstar_list,
-        detJ_interp_list=detJ_list,
-        use_interp=True,
+        sim_id="sim_example",
         log_posterior_func=log_posterior,
         backend_file=test_filename,
         nwalkers=10,


### PR DESCRIPTION
## Summary
- add `load_precomputed_tables` helper that reads lensing grids from `tables/<sim_id>`
- rework `likelihood_single_fast_optimized` to integrate using precomputed `logM_star` and `detJ`
- update `run_mcmc` to accept `sim_id`, load grids on start, and validate their presence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890497d9e8c832da57cfee003412e3d