### PR TITLE
feat: add placeholder for missing tables

### DIFF
--- a/run_mcmc.py
+++ b/run_mcmc.py
@@ -75,7 +75,7 @@ def run_mcmc(
     write_metadata(out_dir / "params.json", params)
     write_metadata(out_dir / "metadata.json", metadata)
 
-    tables = load_precomputed_tables(sim_id)
+    tables = load_precomputed_tables(sim_id, required_count=len(data_df))
     if len(tables) < len(data_df):
         raise ValueError(
             f"Not enough precomputed tables for sim_id '{sim_id}'"


### PR DESCRIPTION
## Summary
- generate minimal placeholder lensing tables if precomputed data are missing
- run MCMC using the fallback tables when real precomputations are absent

## Testing
- `python - <<'PY'
from sl_inference.likelihood import load_precomputed_tables
print(len(load_precomputed_tables('sim_example', required_count=2)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689062e535a0832da43e6f32afa3a13b